### PR TITLE
build: Install headers

### DIFF
--- a/cmake/iotjs.cmake
+++ b/cmake/iotjs.cmake
@@ -495,6 +495,12 @@ set(IOTJS_PUBLIC_HEADERS
   ${LIBUV_HEADERS}
 )
 
+# Install headers
+if("${INCLUDE_INSTALL_DIR}" STREQUAL "")
+  set(INCLUDE_INSTALL_DIR "include/iotjs")
+endif()
+install(FILES ${IOTJS_PUBLIC_HEADERS} DESTINATION ${INCLUDE_INSTALL_DIR})
+
 # Configure the libiotjs
 set(TARGET_LIB_IOTJS libiotjs)
 if(CREATE_SHARED_LIB)


### PR DESCRIPTION
Reintroduce this feature after 99ec3710

It was useful for debian packaging (iotjs-dev)

Relate-to: https://github.com/Samsung/iotjs/pull/1145
Change-Id: Idd9a18bbe692baeb468152df5149374512e9350b
IoT.js-DCO-1.0-Signed-off-by: Philippe Coval p.coval@samsung.com