### PR TITLE
Add a "Hello IoT.js!" program to the tests

### DIFF
--- a/test/hello.js
+++ b/test/hello.js
@@ -1,0 +1,16 @@
+/* Copyright 2019-present Samsung Electronics Co., Ltd. and other contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+console.log("Hello IoT.js!");


### PR DESCRIPTION
The current code base does not contain any "first JavaScript
program" for those who build IoT.js. The existing tests are just
that: tests, giving passed/failed information but nothing eye candy.

This patch adds a simple JS script that can act as a warm welcome
to anyone after the first successful build trying to run something
proving that IoT.js works.

IoT.js-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu