### PR TITLE
Removed unused break in iotjs_env.c

### DIFF
--- a/src/iotjs_env.c
+++ b/src/iotjs_env.c
@@ -190,7 +190,7 @@ bool iotjs_environment_parse_command_line_arguments(iotjs_environment_t* env,
         }
         fprintf(stderr, "\n");
         return false;
-      } break;
+      }
       case OPT_MEM_STATS: {
         env->config.memstat = true;
       } break;


### PR DESCRIPTION
Signed-off-by: bence gabor kis <kisbg@inf.u-szeged.hu>