### PR TITLE
Use absolute paths for file resources

### DIFF
--- a/test/run_pass/test_module_json.js
+++ b/test/run_pass/test_module_json.js
@@ -14,7 +14,7 @@
  */
 
 var assert = require('assert');
-var json = require('./resources/test.json');
+var json = require(process.cwd() + '/resources/test.json');
 
 assert.equal(json.name, 'IoT.js');
 assert.equal(json.author, 'Samsung Electronics Co., Ltd.');


### PR DESCRIPTION
NuttX based operating systems require absolute paths.